### PR TITLE
Update Window Title for Docs

### DIFF
--- a/src/components/DocsHeader.jsx
+++ b/src/components/DocsHeader.jsx
@@ -9,6 +9,7 @@ export function DocsHeader({ title }) {
   let section = navigation.find((section) =>
     section.links.find((link) => link.href === pathname),
   )
+  let link = section.links.find((link) => link.href === pathname)
 
   if (!title && !section) {
     return null
@@ -16,6 +17,7 @@ export function DocsHeader({ title }) {
 
   return (
     <header className="mb-9 space-y-1">
+      <title>{section.title + " | " + link.page_title}</title>
       {section && (
         <p className="font-display text-sm font-medium text-sky-500">
           {section.title}


### PR DESCRIPTION
## What's Done
- Added logic to update window title based on `link.page_title`.
- The navigation object in the gofr repo must be updated for this to work.