### PR TITLE
style: fix footer alignment on smaller screen

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -44,7 +44,7 @@ function FooterUi() {
       <div className="mx-auto max-w-screen-2xl overflow-hidden px-6 py-4 lg:px-8">
         <nav
           aria-label="Footer"
-          className="-mb-6 columns-2 sm:flex sm:justify-center sm:space-x-12"
+          className="-mb-6 flex flex-wrap justify-center gap-5"
         >
           {footerLinks.map((item) => (
             <div key={item.title} className="pb-6">
@@ -58,12 +58,12 @@ function FooterUi() {
             </div>
           ))}
         </nav>
-        <div className="mt-8 flex justify-center space-x-10">
+        <div className="mt-8 flex flex-wrap gap-5 justify-center">
           {socialMediaLinks.map((item, idx) => {
             const { Icon, Link: link } = item
             return (
               <Link
-                  key={link}
+                key={link}
                 href={link}
                 className="text-gray-400 hover:text-gray-500"
                 target="_blank"


### PR DESCRIPTION
before and after screenshot, device screen around 360x800 (example: Samsung S20)

fix cut off icons

![Screenshot 2024-10-10 at 15-58-59 GoFr - An opinionated Go Framework](https://github.com/user-attachments/assets/6eae25a0-6d2a-404c-8dbb-67c8fc32b0e4)
![Screenshot 2024-10-10 at 16-15-40 GoFr - An opinionated Go Framework](https://github.com/user-attachments/assets/1fc9e178-07b1-496a-ae1d-1624302dc048)
