### PR TITLE
Add public folder to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 COPY src src/.
+COPY public public/.
 COPY jsconfig.json .
 COPY next.config.mjs .
 COPY package.json .


### PR DESCRIPTION
Currently the docker image that was being built did not have the public folder containing the images.