### PR TITLE
Fix quick links navigation

### DIFF
--- a/src/components/QuickLinks.jsx
+++ b/src/components/QuickLinks.jsx
@@ -8,20 +8,19 @@ export function QuickLinks({ children }) {
   )
 }
 
-export function QuickLink({ title, description, icon }) {
+export function QuickLink({ title, description, icon, href }) {
   return (
-    <div className="group relative rounded-xl border border-slate-200 dark:border-slate-800">
+    <a href={href} className="group relative rounded-xl border border-slate-200 dark:border-slate-800 block no-underline">
       <div className="absolute -inset-px rounded-xl border-2 border-transparent opacity-0 [background:linear-gradient(var(--quick-links-hover-bg,theme(colors.sky.50)),var(--quick-links-hover-bg,theme(colors.sky.50)))_padding-box,linear-gradient(to_top,theme(colors.indigo.400),theme(colors.cyan.400),theme(colors.sky.500))_border-box] group-hover:opacity-100 dark:[--quick-links-hover-bg:theme(colors.slate.800)]" />
       <div className="relative overflow-hidden rounded-xl p-6">
         <Icon icon={icon} className="h-8 w-8" />
         <h2 className="mt-4 font-display text-base text-slate-900 dark:text-white">
-          <span className="absolute -inset-px rounded-xl" />
           {title}
         </h2>
         <p className="mt-1 text-sm text-slate-700 dark:text-slate-400">
           {description}
         </p>
       </div>
-    </div>
-  )
+    </a>
+  );
 }

--- a/src/components/QuickLinks.jsx
+++ b/src/components/QuickLinks.jsx
@@ -9,8 +9,15 @@ export function QuickLinks({ children }) {
 }
 
 export function QuickLink({ title, description, icon, href }) {
+  const Container = href ? 'a' : 'div';
+  
   return (
-    <a href={href} className="group relative rounded-xl border border-slate-200 dark:border-slate-800 block no-underline">
+    <Container 
+      href={href}
+      className={`group relative rounded-xl border border-slate-200 dark:border-slate-800 block ${
+        href ? 'no-underline hover:cursor-pointer' : ''
+      }`}
+    >
       <div className="absolute -inset-px rounded-xl border-2 border-transparent opacity-0 [background:linear-gradient(var(--quick-links-hover-bg,theme(colors.sky.50)),var(--quick-links-hover-bg,theme(colors.sky.50)))_padding-box,linear-gradient(to_top,theme(colors.indigo.400),theme(colors.cyan.400),theme(colors.sky.500))_border-box] group-hover:opacity-100 dark:[--quick-links-hover-bg:theme(colors.slate.800)]" />
       <div className="relative overflow-hidden rounded-xl p-6">
         <Icon icon={icon} className="h-8 w-8" />
@@ -21,6 +28,6 @@ export function QuickLink({ title, description, icon, href }) {
           {description}
         </p>
       </div>
-    </a>
+    </Container>
   );
 }


### PR DESCRIPTION
Updates the QuickLink component to properly handle hrefs, fixing the broken Quick Start and Examples buttons. Now correctly links to the docs introduction and GitHub examples.
Related to issue  gofr-dev/gofr#1870

https://github.com/user-attachments/assets/4090c57b-8b04-4dc9-ae0f-fa7bd4398f1b



