### PR TITLE
showcase: shared gradient layer + testimonials masonry fix

### DIFF
--- a/src/app/comparison/layout.jsx
+++ b/src/app/comparison/layout.jsx
@@ -1,4 +1,4 @@
 import { MarketingPage } from '@/components/MarketingPage'
 
-const Layout = ({ children }) => <MarketingPage>{children}</MarketingPage>
+const Layout = ({ children }) => <MarketingPage withGradient>{children}</MarketingPage>
 export default Layout

--- a/src/app/migrate/layout.jsx
+++ b/src/app/migrate/layout.jsx
@@ -1,4 +1,4 @@
 import { MarketingPage } from '@/components/MarketingPage'
 
-const Layout = ({ children }) => <MarketingPage>{children}</MarketingPage>
+const Layout = ({ children }) => <MarketingPage withGradient>{children}</MarketingPage>
 export default Layout

--- a/src/app/showcase/page.jsx
+++ b/src/app/showcase/page.jsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { formatNumber } from '@/lib/common'
+import { ShowcaseGradient } from '@/components/ShowcaseGradient'
 import companies from './companies.json'
 import testimonials from '../../../utils/testimonials.json'
 
@@ -53,8 +54,9 @@ export default function ShowcasePage() {
   }, [])
 
   return (
-    <div className="min-h-screen bg-slate-900">
-      <div className="mx-auto max-w-5xl px-4 py-16 sm:px-6 lg:px-8">
+    <div className="relative min-h-screen overflow-x-clip bg-slate-900">
+      <ShowcaseGradient />
+      <div className="relative mx-auto max-w-5xl px-4 py-16 sm:px-6 lg:px-8">
         {/* Hero */}
         <div className="text-center">
           <h1 className="font-display text-4xl font-bold tracking-tight text-white">

--- a/src/app/why-gofr/layout.jsx
+++ b/src/app/why-gofr/layout.jsx
@@ -1,4 +1,4 @@
 import { MarketingPage } from '@/components/MarketingPage'
 
-const Layout = ({ children }) => <MarketingPage>{children}</MarketingPage>
+const Layout = ({ children }) => <MarketingPage withGradient>{children}</MarketingPage>
 export default Layout

--- a/src/components/HomePage.jsx
+++ b/src/components/HomePage.jsx
@@ -7,6 +7,7 @@ import { EcosystemRecognition } from '@/components/EcosystemRecognition'
 import { FadeInOnScroll } from '@/components/FadeInOnScroll'
 import { StaggerChildren } from '@/components/StaggerChildren'
 import blurCyanImage from "@/images/blur-cyan.png";
+import { ShowcaseGradient } from '@/components/ShowcaseGradient'
 import Image from "next/image";
 import React from "react";
 import Testimonials from "@/components/Reviews";
@@ -19,7 +20,8 @@ import Testimonials from "@/components/Reviews";
 // continuous strip rather than two seams.
 export function HomePage() {
   return (
-    <div className="m-auto w-auto max-w-screen-2xl">
+    <div className="relative m-auto w-auto max-w-screen-2xl overflow-x-clip">
+      <ShowcaseGradient />
       {/* Density-matched section padding. Uniform `py-24` everywhere
           made the page feel padded-for-padding's-sake when section
           content was thin (a 100 px marquee strip, a 1-row logo wall).

--- a/src/components/MarketingPage.jsx
+++ b/src/components/MarketingPage.jsx
@@ -1,13 +1,26 @@
+import { ShowcaseGradient } from '@/components/ShowcaseGradient'
+
 // Wrapper for the SEO-only Markdoc pages (/why-gofr, /comparison/*,
 // /migrate/*, /learn, /faq). It supplies the flex container DocsLayout
 // expects, but unlike DocsPage it does NOT render a left sidebar — these
 // pages aren't core navigation, they're SEO landing content. Right-rail
 // "On this page" TOC from DocsLayout still renders. Cross-links to the
 // other SEO pages live in the global footer.
-export function MarketingPage({ children }) {
+//
+// `withGradient` adds the decorative orb layer (ShowcaseGradient).
+// Opt-in because /faq and /learn are reading-mode reference pages
+// where the gradient is just visual noise; /why-gofr, /comparison/*,
+// /migrate/* are positioning surfaces where it belongs.
+export function MarketingPage({ children, withGradient = false }) {
   return (
     <div>
-      <div className="relative mx-auto flex w-full max-w-screen-2xl flex-auto justify-center sm:px-2 lg:px-8 xl:px-12">
+      <div
+        className={
+          'relative mx-auto flex w-full max-w-screen-2xl flex-auto justify-center sm:px-2 lg:px-8 xl:px-12' +
+          (withGradient ? ' overflow-x-clip' : '')
+        }
+      >
+        {withGradient && <ShowcaseGradient />}
         {children}
       </div>
     </div>

--- a/src/components/Reviews.jsx
+++ b/src/components/Reviews.jsx
@@ -9,9 +9,13 @@ export default function Testimonials() {
             {/*<h2 className="text-center text-lg font-semibold leading-8 text-white mb-10">*/}
             {/*    User Testimonials*/}
             {/*</h2>*/}
-            <div className="sm:columns-2 md:columns-3">
+            <div className="gap-x-6 sm:columns-2 md:columns-3">
                 {testimonials.map((testimonial, index) => (
-                    <div key={index} className="group inline-block relative my-3 rounded-xl border cursor-default border-slate-200 dark:border-slate-800 p-1">
+                    // `block break-inside-avoid` keeps each card whole inside
+                    // the CSS multi-column flow. Without it, a tall card gets
+                    // split at the column boundary and the two halves render
+                    // on top of each other on narrow viewports.
+                    <div key={index} className="group block break-inside-avoid w-full relative my-3 rounded-xl border cursor-default border-slate-200 dark:border-slate-800 p-1">
                         <div className="absolute -inset-px rounded-xl border-2 border-transparent opacity-0 [background:linear-gradient(var(--quick-links-hover-bg,theme(colors.sky.50)),var(--quick-links-hover-bg,theme(colors.sky.50)))_padding-box,linear-gradient(to_top,theme(colors.indigo.400),theme(colors.cyan.400),theme(colors.sky.500))_border-box] group-hover:opacity-100 dark:[--quick-links-hover-bg:theme(colors.slate.800)]" />
 
                         <div className="relative overflow-hidden rounded-xl p-6">

--- a/src/components/ShowcaseGradient.jsx
+++ b/src/components/ShowcaseGradient.jsx
@@ -1,0 +1,56 @@
+import Image from 'next/image'
+import blurCyanImage from '@/images/blur-cyan.png'
+import blurIndigoImage from '@/images/blur-indigo.png'
+
+// Decorative gradient layer for the framework's pitch / showcase
+// surfaces — homepage, /why-gofr, /comparison/*, /showcase, /migrate/*.
+// Three pointer-events-none orbs distributed down the page at
+// alternating sides, reusing the cyan + indigo vocabulary the hero
+// already establishes. Drop inside any `relative overflow-x-clip`
+// wrapper.
+//
+// Why an absolute layer instead of a CSS background-image:
+//   - Matches the existing Hero implementation (Image PNGs, opacity).
+//   - Lets us anchor each orb relative to a known parent, so different
+//     pages can opt in without re-tuning a body-level gradient.
+//
+// Why `unoptimized` is mandatory: the site builds with
+// `output: 'export'`, which disables /_next/image. Without unoptimized,
+// Next emits a /_next/image?url=... src that 404s in production and
+// renders as a broken-image icon.
+export function ShowcaseGradient() {
+  return (
+    <>
+      <Image
+        aria-hidden="true"
+        className="pointer-events-none absolute -left-32 top-[30%] hidden select-none opacity-20 sm:block"
+        src={blurCyanImage}
+        alt=""
+        width={530}
+        height={530}
+        loading="lazy"
+        unoptimized
+      />
+      <Image
+        aria-hidden="true"
+        className="pointer-events-none absolute -right-40 top-[55%] hidden select-none opacity-20 sm:block"
+        src={blurIndigoImage}
+        alt=""
+        width={567}
+        height={567}
+        loading="lazy"
+        unoptimized
+      />
+      <Image
+        aria-hidden="true"
+        className="pointer-events-none absolute -left-40 top-[80%] hidden select-none opacity-15 sm:block"
+        src={blurCyanImage}
+        alt=""
+        width={530}
+        height={530}
+        loading="lazy"
+        unoptimized
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- New `ShowcaseGradient` component — three pointer-events-none cyan+indigo orbs distributed down the page, matching the vocabulary the Hero already uses. Drop inside any `relative overflow-x-clip` wrapper.
- Wired into the framework's pitch surfaces only:
  - `/` — replaces the page's inline orb cluster
  - `/why-gofr`, `/comparison/*`, `/migrate/*` — via a new opt-in `withGradient` prop on `MarketingPage`
  - `/showcase` — composed directly into its custom layout
- Reading-mode pages keep their calm canvas — `/faq`, `/learn` also use `MarketingPage` but don't pass `withGradient`. `/docs/**` is untouched.
- **Bug fix in `Reviews.jsx`**: testimonials masonry was splitting tall cards across CSS-column boundaries on narrow viewports, rendering the two halves on top of each other. Added `block break-inside-avoid w-full` to each card and `gap-x-6` between columns.

## Test plan
- [x] `npx next build` succeeds (locally verified before commit).
- [x] All affected routes return 200 in dev (`/`, `/why-gofr`, `/comparison`, `/comparison/gofr-vs-gin`, `/migrate`, `/migrate/from-gin`, `/showcase`, `/faq`, `/learn`).
- [ ] Visual check: gradient appears on the 4 pitch surfaces, absent on `/faq` and `/learn`.
- [ ] Visual check: testimonial cards no longer overlap on tablet-width viewports (~700–1000px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)