### PR TITLE
docs: fix GoFr brand casing in nav descriptions and search breadcrumbs

### DIFF
--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -165,27 +165,47 @@ function HighlightQuery({ text, query }) {
   )
 }
 
+// Known-token map for breadcrumb/segment prettifying. Naive Title
+// Case turned `gofr-vs-gin` into `Gofr Vs Gin` — wrong on both
+// counts (brand mark is `GoFr`, comparator is lowercase `vs`) and
+// `wrap-grpc` into `Wrap Grpc` instead of `Wrap gRPC`. Anything
+// not in this map falls back to plain Title Case.
+const PRETTY_TOKENS = {
+  gofr: 'GoFr',
+  gofrcli: 'GoFr CLI',
+  vs: 'vs',
+  grpc: 'gRPC',
+  graphql: 'GraphQL',
+  api: 'API',
+  cli: 'CLI',
+  http: 'HTTP',
+  https: 'HTTPS',
+  rest: 'REST',
+  faq: 'FAQ',
+}
+
 // Turn a path segment slug into a Title Case label.
-// "wrap-grpc" → "Wrap Grpc", "from-fiber" → "From Fiber".
-// Strict slug-to-words; preserves embedded acronyms only when they're already uppercase.
+// "wrap-grpc" → "Wrap gRPC", "from-fiber" → "From Fiber",
+// "gofr-vs-gin" → "GoFr vs Gin".
 function prettifySegment(seg) {
   if (!seg) return ''
   return seg
     .split(/[-_]/)
-    .map((w) =>
-      w.length === 0
-        ? ''
-        : w === w.toUpperCase()
-        ? w
-        : w.charAt(0).toUpperCase() + w.slice(1),
-    )
+    .map((w) => {
+      if (w.length === 0) return ''
+      const known = PRETTY_TOKENS[w.toLowerCase()]
+      if (known) return known
+      // Already uppercase — preserve embedded acronyms.
+      if (w === w.toUpperCase()) return w
+      return w.charAt(0).toUpperCase() + w.slice(1)
+    })
     .join(' ')
 }
 
 // Build a breadcrumb-shaped path label from a URL.
 // "/docs/datasources/mongodb" → "Datasources › Mongodb"
-// "/docs/references/gofrcli/init" → "References › Gofrcli › Init"
-// "/comparison/gofr-vs-gin" → "Comparison › Gofr Vs Gin"
+// "/docs/references/gofrcli/init" → "References › GoFr CLI › Init"
+// "/comparison/gofr-vs-gin" → "Comparison › GoFr vs Gin"
 function pathBreadcrumb(rawUrl) {
   if (!rawUrl) return ''
   let p = rawUrl.split('#')[0].split('?')[0]

--- a/src/lib/navigation.js
+++ b/src/lib/navigation.js
@@ -1,12 +1,12 @@
 export const navigation = [
     {
         title: 'Quick Start Guide',
-        desc: "Get started with GoFR through our Quick Start Guide. Learn to build scalable applications with easy-to-follow instructions on server setup, database connections, configuration management, and more. Boost your productivity and streamline your development process.",
+        desc: "Get started with GoFr through our Quick Start Guide. Learn to build scalable applications with easy-to-follow instructions on server setup, database connections, configuration management, and more. Boost your productivity and streamline your development process.",
         links: [
             {
                 title: 'Hello Server',
                 href: '/docs/quick-start/introduction',
-                desc: "Getting started with how to write a server using GoFR with basic examples and explanations. Boost your productivity with efficient coding practices and learn to build scalable applications quickly."
+                desc: "Getting started with how to write a server using GoFr with basic examples and explanations. Boost your productivity with efficient coding practices and learn to build scalable applications quickly."
             },
 
             {
@@ -17,12 +17,12 @@ export const navigation = [
             {
                 title: 'Connecting Redis',
                 href: '/docs/quick-start/connecting-redis',
-                desc: "Discover how to connect your GoFR application to Redis for fast in-memory data storage."
+                desc: "Discover how to connect your GoFr application to Redis for fast in-memory data storage."
             },
             {
                 title: 'Connecting MySQL',
                 href: '/docs/quick-start/connecting-mysql',
-                desc: "Step-by-step guide on integrating MySQL with your GoFR application. With managed database connections and new methods for increasing your productivity."
+                desc: "Step-by-step guide on integrating MySQL with your GoFr application. With managed database connections and new methods for increasing your productivity."
             },
             {
                 title: 'Observability',
@@ -82,7 +82,7 @@ export const navigation = [
             {
                 title: 'Authentication',
                 href: '/docs/advanced-guide/authentication',
-                desc: "Implement various authentication methods to secure your GoFR application and protect sensitive endpoints across HTTP and gRPC."
+                desc: "Implement various authentication methods to secure your GoFr application and protect sensitive endpoints across HTTP and gRPC."
             },
             {
                 title: 'Role-Based Access Control (RBAC)',
@@ -358,12 +358,12 @@ export const navigation = [
             {
                 title: 'Context',
                 href: '/docs/references/context',
-                desc: "Discover the GoFR context, an injected object that simplifies request-specific data handling for HTTP, gRPC, and Pub/Sub calls. Learn how it extends Go's context, providing easy access to dependencies like databases, loggers, and HTTP clients. Explore features for reading HTTP requests, binding data, and accessing query and path parameters efficiently, all while reducing application complexity."
+                desc: "Discover the GoFr context, an injected object that simplifies request-specific data handling for HTTP, gRPC, and Pub/Sub calls. Learn how it extends Go's context, providing easy access to dependencies like databases, loggers, and HTTP clients. Explore features for reading HTTP requests, binding data, and accessing query and path parameters efficiently, all while reducing application complexity."
             },
             {
                 title: 'Configs',
                 href: '/docs/references/configs',
-                desc: "Learn how to manage configuration settings in your GoFR applications, including default values for environment variables. This section provides a comprehensive list of all available configurations to streamline your setup."
+                desc: "Learn how to manage configuration settings in your GoFr applications, including default values for environment variables. This section provides a comprehensive list of all available configurations to streamline your setup."
             },
             {
                 title: 'Testing',


### PR DESCRIPTION
The lowercase 'r' is the canonical brand mark (matches the logo). Two website-side spots had drifted to \`GoFR\` / \`Gofr\` / naively title-cased renderings.

## Changes

### \`src/lib/navigation.js\`
Seven \`desc:\` strings used \`GoFR\` through-out the navigation metadata. This is the website's standalone copy; the framework's \`gofr/docs/navigation.js\` overlays it during the framework-docs docker build, so when paired with [gofr#3398](https://github.com/gofr-dev/gofr/pull/3398) the fix lands in both layers.

### \`src/components/Search.jsx\`
\`prettifySegment\` was naive Title Case, so search breadcrumbs rendered slugs like \`gofr-vs-gin\` as **\"Gofr Vs Gin\"** and \`wrap-grpc\` as **\"Wrap Grpc\"**.

Added a small \`PRETTY_TOKENS\` map covering the brand mark and common acronyms; plain words still fall through to Title Case:
- \`gofr\` → \`GoFr\`
- \`gofrcli\` → \`GoFr CLI\`
- \`vs\` → \`vs\` (lowercase, comparator)
- \`grpc\` → \`gRPC\`
- \`graphql\` → \`GraphQL\`
- \`api\`, \`cli\`, \`http\`, \`https\`, \`rest\`, \`faq\` → uppercase

So search breadcrumbs now read **\"Comparison › GoFr vs Gin\"** and **\"References › GoFr CLI\"** instead of the previous mangled forms.

## Out of scope (intentionally)
Real Go identifiers and env-var conventions are left untouched:
- \`RegisterServerWithGofr\` (Go function name in \`gofr/pkg/\` and \`gofr/examples/grpc/\`)
- \`GOFR_TELEMETRY\` and other \`GOFR_*\` env-var names

## Test
- \`npx next build\` succeeds.
- \`grep -rn 'GoFR' src/lib src/components\` returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)