### PR TITLE
feat(pkg): add go-import pages for cloudsql, influxdb, and kv-store/dynamodb

### DIFF
--- a/src/app/pkg/gofr/datasource/cloudsql/layout.jsx
+++ b/src/app/pkg/gofr/datasource/cloudsql/layout.jsx
@@ -1,0 +1,10 @@
+export const metadata = {
+  other: {
+    'go-import': 'gofr.dev git https://github.com/gofr-dev/gofr',
+    'go-source': 'gofr.dev https://github.com/gofr-dev/gofr https://github.com/gofr-dev/gofr/tree/main{/dir} https://github.com/gofr-dev/gofr/blob/main{/dir}/{file}#L{line}'
+  },
+}
+
+export default function RootLayout({ children }) {
+  return children
+}

--- a/src/app/pkg/gofr/datasource/cloudsql/page.jsx
+++ b/src/app/pkg/gofr/datasource/cloudsql/page.jsx
@@ -1,0 +1,11 @@
+import { PkgRedirect } from '@/components/PkgRedirect'
+
+
+export const metadata = {
+  title: 'gofr/datasource/cloudsql — GoFr Go Package',
+  description: 'Go module path for gofr/datasource/cloudsql. This redirect-only page sends visitors to the GoFr documentation for setup, configuration, and usage examples.',
+}
+
+export default function Page() {
+  return <PkgRedirect name="gofr/datasource/cloudsql" docsPath="/docs/datasources/cloudsql" />
+}

--- a/src/app/pkg/gofr/datasource/influxdb/layout.jsx
+++ b/src/app/pkg/gofr/datasource/influxdb/layout.jsx
@@ -1,0 +1,10 @@
+export const metadata = {
+  other: {
+    'go-import': 'gofr.dev git https://github.com/gofr-dev/gofr',
+    'go-source': 'gofr.dev https://github.com/gofr-dev/gofr https://github.com/gofr-dev/gofr/tree/main{/dir} https://github.com/gofr-dev/gofr/blob/main{/dir}/{file}#L{line}'
+  },
+}
+
+export default function RootLayout({ children }) {
+  return children
+}

--- a/src/app/pkg/gofr/datasource/influxdb/page.jsx
+++ b/src/app/pkg/gofr/datasource/influxdb/page.jsx
@@ -1,0 +1,11 @@
+import { PkgRedirect } from '@/components/PkgRedirect'
+
+
+export const metadata = {
+  title: 'gofr/datasource/influxdb — GoFr Go Package',
+  description: 'Go module path for gofr/datasource/influxdb. This redirect-only page sends visitors to the GoFr documentation for setup, configuration, and usage examples.',
+}
+
+export default function Page() {
+  return <PkgRedirect name="gofr/datasource/influxdb" docsPath="/docs/datasources/influxdb" />
+}

--- a/src/app/pkg/gofr/datasource/kv-store/dynamodb/layout.jsx
+++ b/src/app/pkg/gofr/datasource/kv-store/dynamodb/layout.jsx
@@ -1,0 +1,10 @@
+export const metadata = {
+  other: {
+    'go-import': 'gofr.dev git https://github.com/gofr-dev/gofr',
+    'go-source': 'gofr.dev https://github.com/gofr-dev/gofr https://github.com/gofr-dev/gofr/tree/main{/dir} https://github.com/gofr-dev/gofr/blob/main{/dir}/{file}#L{line}'
+  },
+}
+
+export default function RootLayout({ children }) {
+  return children
+}

--- a/src/app/pkg/gofr/datasource/kv-store/dynamodb/page.jsx
+++ b/src/app/pkg/gofr/datasource/kv-store/dynamodb/page.jsx
@@ -1,0 +1,11 @@
+import { PkgRedirect } from '@/components/PkgRedirect'
+
+
+export const metadata = {
+  title: 'gofr/datasource/kv-store/dynamodb — GoFr Go Package',
+  description: 'Go module path for gofr/datasource/kv-store/dynamodb. Redirects to the GoFr documentation for setup, configuration, and usage examples.',
+}
+
+export default function Page() {
+  return <PkgRedirect name="gofr/datasource/kv-store/dynamodb" docsPath="/docs/datasources/getting-started" />
+}

--- a/src/lib/navigation.js
+++ b/src/lib/navigation.js
@@ -296,6 +296,11 @@ export const navigation = [
                 desc: "Learn how to connect to and interact with clickhouse database in GoFr."
             },
             {
+                title: "Cloud SQL",
+                href: "/docs/datasources/cloudsql",
+                desc: "Learn how to connect to and interact with Google Cloud SQL in GoFr using IAM authentication."
+            },
+            {
                 title: "CockroachDB",
                 href: "/docs/datasources/cockroachdb",
                 desc: "Learn how to connect to and interact with CockroachDB in GoFr."


### PR DESCRIPTION
## Problem

Three datasource modules had published tags but `go get` fails for them because gofr.dev returns 404 on their vanity import paths — Go's toolchain can't find the `go-import` meta tag and falls back to the root module.

## Changes

Adds `layout.jsx` + `page.jsx` for three missing datasource modules and adds Cloud SQL to the navigation.

---

## Release notes

### Cloud SQL — `gofr.dev/pkg/gofr/datasource/cloudsql` **v0.1.0** _(new)_

New datasource that connects GoFr applications to Google Cloud SQL (Postgres/MySQL) with **GCP IAM database authentication** — no static DB password, no Cloud SQL Auth Proxy sidecar. Controlled by the `DB_IAM_AUTH` config key; when off, it delegates to the standard SQL path, so the same `app.AddSQLDB(cloudsql.New(app.Config))` line works identically in local and cloud environments.

Credentials resolve via Application Default Credentials (supports Workload Identity Federation). The module lives in its own `go.mod` so only apps that import it pull the `cloudsqlconn` and GCP SDK — no new dependencies land in the core module.

### InfluxDB — `gofr.dev/pkg/gofr/datasource/influxdb` **v0.1.1** _(patch)_

- **fix(metrics):** extended datasource latency histogram bucket upper bound from 10 ms to 3 minutes, aligning with all other datasource modules (#3568)
- **chore:** bumped Go toolchain to 1.26; updated OpenTelemetry and other dependencies

### DynamoDB — `gofr.dev/pkg/gofr/datasource/kv-store/dynamodb` **v0.1.1** _(patch)_

- **fix(metrics):** extended datasource latency histogram bucket upper bound from 10 ms to 3 minutes (#3568)
- **chore:** bumped Go toolchain to 1.26; updated AWS SDK, OpenTelemetry, and other dependencies across multiple batches

---

## Test plan

- [ ] After deploy, verify `go get gofr.dev/pkg/gofr/datasource/cloudsql@v0.1.0` resolves correctly
- [ ] Verify `go get gofr.dev/pkg/gofr/datasource/influxdb@v0.1.1` resolves correctly
- [ ] Verify `go get gofr.dev/pkg/gofr/datasource/kv-store/dynamodb@v0.1.1` resolves correctly
- [ ] Confirm `gofr.dev/pkg/gofr/datasource/cloudsql?go-get=1` returns HTTP 200 with `go-import` meta tag