### PR TITLE
chore: move the website build off EOL Node onto 24 LTS (#223)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 18.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 24.x
 
       - name: Build App
         run: |
@@ -61,10 +61,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js 18.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 24.x
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -113,10 +113,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js 18.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 24.x
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,13 @@
 #   docker run --rm -p 3001:3000 gofr-website:local
 
 # ---------- builder ----------
-FROM node:23.11.1-alpine3.21 AS builder
+# Node 24 is the active LTS (EOL 2028-04-30). Tracked as the major tag
+# rather than an exact patch pin: this repo has no Renovate/Dependabot,
+# and the previous exact pin (node:23.11.1-alpine3.21) silently outlived
+# its line — v23 was never LTS and went EOL 2025-06-01. A floating major
+# picks up patch + Alpine security updates on rebuild and only needs a
+# human when the major itself goes EOL.
+FROM node:24-alpine AS builder
 
 RUN apk add --no-cache libc6-compat
 


### PR DESCRIPTION
**Description:**

Fixes #223.

Moves this repo's two Node runtimes — the Docker builder stage and CI — onto Node 24 LTS.

**1. `Dockerfile` builder stage: `node:23.11.1-alpine3.21` → `node:24-alpine`**

v23 is an **odd-numbered line that was never LTS**, and it went end-of-life on **2025-06-01**. It receives no security patches, including for the bundled OpenSSL and undici.

This is not a peripheral image. `gofr-dev/gofr`'s `docs/Dockerfile` does `FROM ghcr.io/gofr-dev/website:${WEBSITE_TAG} AS builder`, layers the framework docs on top, and runs `npm run build` — so this stage is the runtime that actually performs `next build` for **production `gofr.dev`**, on both the prod and stage deploy paths.

**2. `.github/workflows/package.yml`: `node-version: 18.x` → `24.x` in all three jobs**

v18 went EOL 2025-04-30. Included here rather than split off because leaving it would mean the PR check validates `yarn install && yarn build` on a runtime that is both unsupported *and* no longer the one the shipped image uses — CI would be green against something that never runs in production. Companion to gofr-dev/gofr#3871, which fixed the same pin in the deploy workflows on the framework side.

**Why the major tag and not another exact patch pin**

The builder now tracks `node:24-alpine` rather than `node:24.19.0-alpineX.Y`. This repo has no Renovate or Dependabot configuration, so an exact pin has nothing to bump it — which is exactly how `23.11.1` came to outlive its support line unnoticed. A floating major picks up patch and Alpine security updates on every rebuild and only needs human attention when the major itself approaches EOL (2028-04-30).

Happy to switch to an exact pin if you'd rather, but I'd suggest pairing that with a Renovate config.

**Verification**

The issue noted that `next@13.4.16` and `sharp@^0.32.6` (native binaries) were the likeliest things to break on Node 24. Both were checked — all of the below on `node:24-alpine`, Node **v24.19.0**, Yarn **1.22.22**:

| check | result |
|---|---|
| `yarn install --frozen-lockfile` | exit 0, lockfile satisfied, no resolution drift |
| `docker build --target builder` (what gofr's deploy uses) | green |
| `docker build` full image (what `package.yml` publishes) | green |
| `next build` static export | 33 files in `/app/out` |
| nginx runtime stage | serves all 33 from `/usr/share/nginx/html`, nginx 1.27.5 |
| `sharp@0.32.6` native load | OK — libvips 8.14.5, no rebuild needed |
| `prebuild` scripts (`fetch-github-stars`, `generate-changelog-rss`, `generate-llms-full`) | all exit 0 |

No new warnings beyond what the build already emitted: the pre-existing unmet-peer-dependency set (`@algolia/autocomplete-*`, `autoprefixer`/`postcss`, `ts-api-utils`), a `url.parse()` `DEP0169` deprecation from a transitive dep, and the existing `/certificate` client-rendering notice from Next.

**Breaking Changes (if applicable):**

None. No application code, dependency, or lockfile changes — `package.json` and `yarn.lock` are untouched. Build output is byte-for-byte the same set of 33 exported files.

**Additional Information:**

`package.json` declares no `engines` field, so nothing constrained the major.

Worth flagging for a follow-up, out of scope here: this repo has no Renovate/Dependabot, which is the underlying reason both pins went stale silently rather than either one being noticed. A minimal Renovate config covering Docker base images and `actions/*` would prevent a third instance of this.
