### PR TITLE
feat(pkg): add go-import page for metrics/exporters/gcp

### DIFF
--- a/src/app/pkg/gofr/metrics/exporters/gcp/layout.jsx
+++ b/src/app/pkg/gofr/metrics/exporters/gcp/layout.jsx
@@ -1,0 +1,10 @@
+export const metadata = {
+  other: {
+    'go-import': 'gofr.dev git https://github.com/gofr-dev/gofr',
+    'go-source': 'gofr.dev https://github.com/gofr-dev/gofr https://github.com/gofr-dev/gofr/tree/main{/dir} https://github.com/gofr-dev/gofr/blob/main{/dir}/{file}#L{line}'
+  },
+}
+
+export default function RootLayout({ children }) {
+  return children
+}

--- a/src/app/pkg/gofr/metrics/exporters/gcp/page.jsx
+++ b/src/app/pkg/gofr/metrics/exporters/gcp/page.jsx
@@ -1,0 +1,11 @@
+import { PkgRedirect } from '@/components/PkgRedirect'
+
+
+export const metadata = {
+  title: 'gofr/metrics/exporters/gcp — GoFr Go Package',
+  description: 'Go module path for gofr/metrics/exporters/gcp. This redirect-only page sends visitors to the GoFr documentation for setup, configuration, and usage examples.',
+}
+
+export default function Page() {
+  return <PkgRedirect name="gofr/metrics/exporters/gcp" docsPath="/docs/references/configs" />
+}


### PR DESCRIPTION
## What

Adds the missing vanity-import route for `gofr.dev/pkg/gofr/metrics/exporters/gcp`.

## Why

That path is its own Go module in the gofr repo, but it **cannot be fetched from outside the repository** — the vanity server returns 404 with no `go-import` meta tag, so resolution fails before the module's tags are ever consulted:

```
$ curl -s -o /dev/null -w '%{http_code}\n' 'https://gofr.dev/pkg/gofr/metrics/exporters/gcp?go-get=1'
404

$ curl https://proxy.golang.org/gofr.dev/pkg/gofr/metrics/exporters/gcp/@v/list
not found: unrecognized import path "gofr.dev/pkg/gofr/metrics/exporters/gcp":
reading https://gofr.dev/pkg/gofr/metrics/exporters/gcp?go-get=1: 404 Not Found
```

Every route under `src/app/pkg` is hand-written, and the tree only ever covered `pkg/gofr/datasource/*`. The `metrics` tree does not exist at all, so `/pkg/gofr/metrics`, `/pkg/gofr/metrics/exporters` and the module path itself all 404.

## Approach

Identical to #222 (cloudsql, influxdb, kv-store/dynamodb) and #205 (azure):

- `layout.jsx` — carries the `go-import` / `go-source` metadata. **Byte-identical** to the existing datasource layouts (verified with `diff` against `cloudsql/layout.jsx`).
- `page.jsx` — a `PkgRedirect` page, so the route actually renders and returns 200. A `layout.jsx` on its own is not a route in the App Router and would still 404.

`docsPath` points at `/docs/references/configs`, which is where `METRICS_EXPORTER=gcp` is documented. The custom-metrics guide does not mention the exporter.

## Verification

Structural clone of a pattern already deployed and working; I did not run a local `next build` (the `prebuild` step makes live GitHub calls). Post-merge check:

```
curl -s -o /dev/null -w '%{http_code}\n' 'https://gofr.dev/pkg/gofr/metrics/exporters/gcp?go-get=1'   # expect 200
```

## Note — this is one half of the fix

Ref gofr-dev/gofr#4112. The module has also **never been tagged**: the batch of 26 submodule tags was cut at `285d3d2ec` (the merge of gofr#3928, the PR that fixed this exporter's `go.mod`) and covered `pkg/gofr/datasource/*` only.

This PR must land and deploy **first** — a tag is useless while the meta lookup 404s. The tag `pkg/gofr/metrics/exporters/gcp/v0.1.0` then needs pushing on the gofr repo separately.